### PR TITLE
Replace stale Travis setup with safe GitHub Actions checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  legacy-ios-validation:
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run static safety checks
+        run: scripts/ci-static.sh
+
+      - name: Validate the Xcode workspace
+        run: >-
+          xcodebuild
+          -workspace Furni.xcworkspace
+          -scheme Furni
+          -list
+          CODE_SIGNING_ALLOWED=NO
+          CODE_SIGNING_REQUIRED=NO
+
+      - name: Probe the unsigned legacy build
+        run: scripts/ci-unsigned-build-probe.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ This project is written in Swift 2.0 so Furni requires Xcode 7 to build and run.
 
 Furni for iOS is compatible with iOS 9+.
 
+The GitHub Actions workflow performs read-only project checks and an unsigned
+simulator build probe. Current Xcode releases cannot compile Swift 2, so CI
+accepts only that documented compatibility failure and fails on other errors.
+It does not install credentials, sign an app, deploy, or contact service
+providers.
+
 ## Authors
 
 * [Romain Huet](https://twitter.com/romainhuet)

--- a/scripts/ci-static.sh
+++ b/scripts/ci-static.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+test ! -e .travis.yml
+test -f Furni.xcworkspace/contents.xcworkspacedata
+test -f Furni.xcodeproj/xcshareddata/xcschemes/Furni.xcscheme
+
+plutil -lint Furni/Info.plist Furni/Furni.entitlements FurniTests/Info.plist
+cmp -s Podfile.lock Pods/Manifest.lock
+
+if find . -path ./.git -prune -o -type f \( \
+  -name '*.p12' -o \
+  -name '*.mobileprovision' -o \
+  -name '*.pem' -o \
+  -name '*.key' -o \
+  -name '*.cer' \
+\) -print -quit | grep -q .; then
+  echo 'Credential or signing material must not be committed.' >&2
+  exit 1
+fi
+
+if git grep -I -n -E -- \
+  'BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|encrypted_[A-Za-z0-9_]+:|secure:[[:space:]]*[A-Za-z0-9]' \
+  -- ':!scripts/ci-static.sh'; then
+  echo 'Potential private key or encrypted CI credential found.' >&2
+  exit 1
+fi
+
+if git grep -I -n -E -- \
+  'pull_request_target|permissions:[[:space:]]*write-all|persist-credentials:[[:space:]]*true' \
+  -- '.github/workflows/*.yml' '.github/workflows/*.yaml'; then
+  echo 'Workflow requests an unsafe trigger, permission, or persisted credential.' >&2
+  exit 1
+fi

--- a/scripts/ci-unsigned-build-probe.sh
+++ b/scripts/ci-unsigned-build-probe.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+log_file="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/furni-xcodebuild.log"
+
+set +e
+xcodebuild \
+  -workspace Furni.xcworkspace \
+  -scheme Furni \
+  -configuration Debug \
+  -sdk iphonesimulator \
+  CODE_SIGNING_ALLOWED=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  COMPILER_INDEX_STORE_ENABLE=NO \
+  build 2>&1 | tee "$log_file"
+build_status=${PIPESTATUS[0]}
+set -e
+
+if [[ $build_status -eq 0 ]]; then
+  exit 0
+fi
+
+if grep -Fq "SWIFT_VERSION '' is unsupported" "$log_file"; then
+  echo 'The unsigned build reached the documented Swift 2/Xcode 7 compatibility boundary.'
+  exit 0
+fi
+
+echo 'The unsigned build failed for an unexpected reason.' >&2
+exit "$build_status"


### PR DESCRIPTION
## Summary

- replace the 2016 Travis/Xcode 7.3 experiment with a pinned, read-only GitHub Actions workflow
- validate project metadata, Pod lock consistency, and absence of signing/credential files
- run an unsigned simulator build probe that accepts only the repository's documented Swift 2/Xcode 7 incompatibility
- document that CI never signs, deploys, or contacts service providers

## Review evidence

- PR #3 is conflict-dirty, has no checks, and contains 25 Travis-only commits from January 21, 2016
- its final target is Xcode 7.3/iOS 9.3; Travis still documents that legacy image, but it is not a current toolchain baseline
- current Xcode can parse the workspace and reaches the expected unsupported Swift-version boundary with signing disabled
- full-history and worktree Gitleaks scans found only duplicated AWS SDK documentation examples; no private keys, certificates, provisioning profiles, or encrypted Travis variables were found

## Local gates

- `actionlint`
- `bash -n` and `shellcheck`
- `scripts/ci-static.sh`
- `xcodebuild -list` with signing disabled
- `scripts/ci-unsigned-build-probe.sh`
- Gitleaks worktree and full-history scans
